### PR TITLE
feat: new issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -1,0 +1,82 @@
+name: "🐞 Bug Report"
+description: Create a report to help us improve, Ask questions in Discussions / 创建一个问题报告以帮助我们改进，提问请到 Discussions
+title: "[Bug]: "
+labels: ["waiting for maintainer"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Report errors and exceptions found in G6.
+
+        Before submitting a new bug/issue, please check the links below to see if there is a solution or question posted there already:
+
+        ---
+
+        反馈在 G6 中发现的错误、异常。
+
+        在提交新 issue 之前，先通过以下链接检查是否存在相同问题:
+
+        > [Issues](https://github.com/antvis/G6/issues) | [Closed Issues](https://github.com/antvis/G6/issues?q=is:issue+is:closed) | [Discussions](https://github.com/antvis/G6/discussions)
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug / 问题描述
+      placeholder: |
+        If there is a code block, please use Markdown syntax, such as:
+        如包含代码块，请使用 Markdown 语法，如：
+
+        ```javascript
+        // Your code here
+        ```
+    validations:
+      required: true
+  - type: input
+    id: link
+    attributes:
+      label: Reproduction link / 复现链接
+      placeholder: |
+        CodeSandbox / StackBlitz / ...
+    validations:
+      required: false
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce the Bug or Issue / 重现步骤
+    validations:
+      required: false
+  - type: dropdown
+    id: version
+    attributes:
+      label: G6 Version / G6 版本
+      options:
+        - Please select / 请选择
+        - 🆕 5.x
+        - 4.x
+        - 3.x
+    validations:
+      required: true
+  - type: checkboxes
+    id: OS
+    attributes:
+      label: OS / 操作系统
+      options:
+        - label: macOS
+        - label: Windows
+        - label: Linux
+        - label: Others / 其他
+    validations:
+      required: true
+  - type: checkboxes
+    id: Browser
+    attributes:
+      label: Browser / 浏览器
+      options:
+        - label: Chrome
+        - label: Edge
+        - label: Firefox
+        - label: Safari (Limited support / 有限支持)
+        - label: IE (Nonsupport / 不支持)
+        - label: Others / 其他
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/2.feature.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature.yml
@@ -1,0 +1,21 @@
+name: '💡 Feature Request'
+description: I have a suggestion (and may want to implement it) / 我有一个建议（或者想参与贡献）
+title: '[Feat]: '
+labels: ['waiting for maintainer']
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the feature / 功能描述
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Are you willing to contribute? / 是否愿意参与贡献？
+      options:
+        - Please select / 请选择
+        - ✅ Yes / 是
+        - ❌ No / 否
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/3.docs_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/3.docs_feedback.yml
@@ -1,0 +1,33 @@
+name: '📖 Docs Feedback'
+description: Improve documentation about G6 / 助力 G6 打造出更易于上手操作以及便捷查阅的文档
+labels: ['waiting for maintainer', 'documentation 📖']
+title: '[docs] '
+body:
+  - type: input
+    id: page-url
+    attributes:
+      label: Related page
+      description: Which page of the documentation is this about?
+      placeholder: https://g6.antv.antgroup.com/
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Kind of issue
+      description: What kind of problem are you facing?
+      options:
+        - Unclear explanations
+        - Missing information
+        - Broken demo
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Issue description
+      description: |
+        Let us know what went wrong when you were using this documentation and what we could do to improve it | 请告知您在使用此文档时遇到的问题以及我们可以改进的地方
+  - type: textarea
+    attributes:
+      label: Context
+      description: What are you trying to accomplish? Providing context helps us come up with a solution that is more useful in the real world | 您希望实现什么目标？提供上下文有助于我们提出更实用的解决方案

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+# Ref: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+blank_issues_enabled: false
+contact_links:
+  - name: 📝 Question
+    url: https://github.com/antvis/github-config/discussions/new?category=q-a
+    about: Ask the community for help / 向社区寻求帮助
+  - name: 💬 Join Discussion Group
+    url: https://qr.dingtalk.com/action/joingroup?code=v1,k1,rQHsK/OOTPX8ixM/DaXcL3goIYpnpKr/AFIonmA1SOM=&_dt_no_comment=1&origin=11?
+    about: Join DingTalk discussion group / 加入钉钉讨论群

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.lh
+.history


### PR DESCRIPTION
This pull request introduces new issue templates for bug reports, feature requests, and documentation feedback, along with a configuration file to manage these templates. The changes aim to streamline the issue reporting process and improve user interaction.

New issue templates:

* [`.github/ISSUE_TEMPLATE/1.bug_report.yml`](diffhunk://#diff-fbea02d1a8c4b6452575e3fa3b45be3883274c7bb44afafef3e9c39e666d819eR1-R82): Added a detailed bug report template with fields for description, reproduction link, steps to reproduce, G6 version, operating system, and browser.
* [`.github/ISSUE_TEMPLATE/2.feature.yml`](diffhunk://#diff-210083c1681a7905dd62ad321fa031776e011606b8257cd219ee05e4114828a6R1-R21): Introduced a feature request template with fields for feature description and willingness to contribute.
* [`.github/ISSUE_TEMPLATE/3.docs_feedback.yml`](diffhunk://#diff-0b258310de300ec6908721b3ff00fa2d5f2557b8038e377d1f8db235f4a80bc6R1-R33): Created a documentation feedback template with fields for related page URL, type of issue, issue description, and context.

Configuration for issue templates:

* [`.github/ISSUE_TEMPLATE/config.yml`](diffhunk://#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2R1-R9): Added configuration to disable blank issues and provided contact links for questions and joining a discussion group.