### PR TITLE
feat: github actions to triage issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/3.docs_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/3.docs_feedback.yml
@@ -1,7 +1,7 @@
-name: '📖 Docs Feedback'
+name: "📖 Docs Feedback"
 description: Improve documentation about G6 / 助力 G6 打造出更易于上手操作以及便捷查阅的文档
-labels: ['waiting for maintainer', 'documentation 📖']
-title: '[docs] '
+labels: ["waiting for maintainer"]
+title: "[docs]: "
 body:
   - type: input
     id: page-url

--- a/.github/workflows/check-issue-label.yml
+++ b/.github/workflows/check-issue-label.yml
@@ -1,0 +1,43 @@
+# This workflow automatically removes the 'waiting for maintainer' label 
+# when certain labels (like 'waiting for author', 'need improvement', etc.) 
+# are added to an issue
+name: Check Issue Label
+
+on:
+  issues:
+    types:
+      - labeled
+
+permissions: {}
+
+jobs:
+  check-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const labelsToCheck = ['waiting for author', 'need improvement', 'bug 🐛', 'documentation 📖', 'feature 💡', 'question 💬', 'notabug', 'stale', 'wontfix', 'duplicate'];
+
+            const labelToRemove = 'waiting for maintainer';
+
+            const newLabel = context.payload.label.name;
+
+            if (labelsToCheck.includes(newLabel)) {
+                const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                });
+
+                if (labels.some(label => label.name === labelToRemove)) {
+                  await github.rest.issues.removeLabel({
+                    issue_number: context.issue.number,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: labelToRemove,
+                  });
+                }
+            }

--- a/.github/workflows/ensure-triage-label.yml
+++ b/.github/workflows/ensure-triage-label.yml
@@ -1,0 +1,35 @@
+name: Ensure triage label is present
+
+on:
+  label:
+    types:
+      - deleted
+  issues:
+    types:
+      - opened
+
+permissions: {}
+
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const { data: labels } = await octokit.rest.issues.listLabelsOnIssue({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            if (labels.length <= 0) {
+              await octokit.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ['waiting for maintainer']
+              })
+            }

--- a/.github/workflows/ensure-triage-label.yml
+++ b/.github/workflows/ensure-triage-label.yml
@@ -19,17 +19,19 @@ jobs:
       - uses: actions/github-script@v7.0.1
         with:
           script: |
-            const { data: labels } = await octokit.rest.issues.listLabelsOnIssue({
+            const labelToTriage = 'waiting for maintainer';
+
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
             });
 
             if (labels.length <= 0) {
-              await octokit.rest.issues.addLabels({
+              await github.rest.issues.addLabels({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                labels: ['waiting for maintainer']
+                labels: [labelToTriage]
               })
             }

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,0 +1,42 @@
+name: No Response
+
+# `issues`.`closed`, `issue_comment`.`created`, and `scheduled` event types are required for this Action
+# to work properly.
+on:
+  issues:
+    types:
+      - closed
+  issue_comment:
+    types:
+      - created
+  schedule:
+    # These runs in our repos are spread evenly throughout the day to avoid hitting rate limits.
+    # If you change this schedule, consider changing the remaining repositories as well.
+    # Runs at 12 am, 12 pm
+    - cron: "0 0,12 * * *"
+
+permissions: {}
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: MBilalShafi/no-response-add-label@0.0.6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Number of days of inactivity before an Issue is closed for lack of response
+          daysUntilClose: 14
+          # Label requiring a response
+          responseRequiredLabel: "waiting for author"
+          # Label to add back when required label is removed
+          optionalFollowupLabel: "waiting for maintainer"
+          # Comment to post when closing an Issue for lack of response. Set to `false` to disable
+          closeComment: >
+            🚫 This issue has been automatically closed due to inactivity and missing key information. Feel free to reopen it if you have any updates.
+
+            ---
+
+            🚫 此议题由于长时间没有活动而自动关闭了。如果你有更多信息，欢迎随时重新开启讨论哦。

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .lh
 .history
+.vscode


### PR DESCRIPTION
This pull request introduces several new GitHub Actions workflows and modifies an existing issue template to improve issue management and documentation feedback processes. The changes include adding workflows for label management and issue response handling.

New workflows:

* [`.github/workflows/check-issue-label.yml`](diffhunk://#diff-e20b9a6b733af840bee0273c8519e0852ea6031871ce46322ea54ff613c844d4R1-R43): Adds a workflow to automatically remove the 'waiting for maintainer' label when certain other labels are added to an issue.
* [`.github/workflows/ensure-triage-label.yml`](diffhunk://#diff-69243593ca8317c41722d48eb86a688358fde6ddab6c3ff0170780526f4223c9R1-R37): Adds a workflow to ensure that the 'waiting for maintainer' label is present on issues when they are opened or when labels are deleted.
* [`.github/workflows/no-response.yml`](diffhunk://#diff-f88246a3dee8080e206a12626ee68a976bfd86a1e790c525a43a59e03661f2a0R1-R42): Adds a workflow to automatically close issues after 14 days of inactivity and add a comment explaining the closure.

Modification to existing issue template:

* [`.github/ISSUE_TEMPLATE/3.docs_feedback.yml`](diffhunk://#diff-0b258310de300ec6908721b3ff00fa2d5f2557b8038e377d1f8db235f4a80bc6L1-R4): Updates the labels and title format for the 'Docs Feedback' issue template.