### PR TITLE
feat: quickly mark duplicate issues

### DIFF
--- a/.github/workflows/mark-duplicate.yml
+++ b/.github/workflows/mark-duplicate.yml
@@ -1,0 +1,23 @@
+name: Issue Mark Duplicate
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions: {}
+
+jobs:
+  mark-duplicate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: mark-duplicate
+        uses: actions-cool/issues-helper@v3.6.0
+        with:
+          actions: "mark-duplicate"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          duplicate-labels: "duplicate"
+          remove-labels: "waiting for maintainer"
+          close-issue: true


### PR DESCRIPTION
使用  [Issues Helper](https://github.com/actions-cool/issues-helper/tree/v3.6.0/?tab=readme-ov-file#mark-duplicate)  来快速标记重复问题，仅适用于 issue 新增评论或编辑评论的场景。

如果发现一个重复的 issue，可以按照以下步骤快速处理：

1. 在 issue 下发表评论，格式为：
   ```
   Duplicate of #12
   ```
   其中 `#12` 是原始 issue 的编号

2. 当发表此评论后，工作流会自动：
   - 为 issue 添加 "duplicate" 标签
   - 移除 "waiting for maintainer" 标签（如果存在）
   - 关闭该 issue
   - 在评论中创建到原始 issue 的引用链接