### PR TITLE
feat: auto close issues if labeled as negative statuses

### DIFF
--- a/.github/workflows/auto-closing-message.yml
+++ b/.github/workflows/auto-closing-message.yml
@@ -1,0 +1,136 @@
+name: Auto Close Issue
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  auto-close:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Warn Inactive Issue Before Close
+        if: github.event.label.name == 'stale'
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "create-comment"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            ⚠️ This issue has been automatically closed due to inactivity. 
+
+            - If the issue is still relevant and important to you, feel free to:
+              1. Reopen with additional information
+              2. Create a new issue with updated context
+              3. Reference any related issues or discussions
+
+            We close inactive issues to keep our backlog manageable and focused on active issues.
+
+            Your contribution makes our project better! 🌟
+
+            ---
+
+            ⚠️ 由于长期无活动，此 issue 已被自动关闭。
+
+            - 如果这个问题对您来说仍然重要，您可以：
+              1. 重新打开并提供补充信息
+              2. 创建一个新的 issue 并更新相关背景
+              3. 关联相关的 issue 或讨论
+
+            为了更好地维护项目，我们需要定期清理不活跃的问题。
+
+            感谢您为开源添砖加瓦！🌟
+          emoji: "heart"
+      - name: Close Inactive Issue
+        if: github.event.label.name == 'stale'
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "close-issue"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+      - name: Comment Won't Fix Issue Before Close
+        if: github.event.label.name == 'wontfix'
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "create-comment"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            🚫 This issue has been marked as "Won't Fix". Here's why:
+
+            - The described behavior is working as intended
+            - The request falls outside our project scope/goals
+            - The cost/benefit ratio doesn't justify the change
+
+            If you have new information that might change this decision, feel free to:
+            1. Share your additional context
+            2. Propose alternative solutions
+            3. Start a discussion to explore different approaches
+
+            Thank you for your understanding and engagement! 🙏
+
+            ---
+
+            🚫 此 issue 被标记为"不予修复"，原因如下：
+
+            - 当前行为符合设计预期
+            - 该请求超出项目范围/目标
+            - 投入产出比不足以支持此变更
+
+            如果您有任何新的想法或建议，欢迎：
+            1. 分享更多上下文
+            2. 提出替代方案
+            3. 发起讨论以探索不同思路
+
+            感谢理解与支持！🙏
+          emoji: "heart"
+      - name: Close Won't Fix Issue
+        if: github.event.label.name == 'wontfix'
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "close-issue"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+      - name: Comment Notabug Issue Before Close
+        if: github.event.label.name == 'notabug'
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "create-comment"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            ✅ After careful review, we've determined this is not a bug. Here's why:
+
+            - The current behavior is working as designed
+            - This might be a misunderstanding of the feature
+            - The issue cannot be reproduced with the provided information
+
+            If you still believe this is a bug, please:
+            1. Provide a minimal reproduction
+            2. Share your expected behavior
+            3. Include more detailed environment information
+
+            Thank you for helping us improve our project! 💫
+
+            ---
+
+            ✅ 经过仔细核查，这并非一个 bug，原因如下：
+
+            - 当前表现符合设计预期
+            - 可能是对功能理解有所偏差
+            - 基于已提供信息无法复现问题
+
+            如果您仍认为这是一个 bug，建议：
+            1. 提供最小复现示例
+            2. 说明您期望的表现
+            3. 补充更详细的环境信息
+
+            期待您的反馈！💫
+          emoji: "heart"
+      - name: Close Notabug Issue
+        if: github.event.label.name == 'notabug'
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "close-issue"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/auto-comment.yml
+++ b/.github/workflows/auto-comment.yml
@@ -11,8 +11,8 @@ jobs:
       issues: write
     steps:
       - name: Warn Bad Issue
-        if: ${{ github.event.label.name == 'need improvement' }}
-        uses: actions-cool/issues-helper@v3.6.0
+        if: github.event.label.name == 'need improvement'
+        uses: actions-cool/issues-helper@v3
         with:
           actions: "create-comment"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
利用 [Issue Helper - Create Comment/Close Issue](https://github.com/actions-cool/issues-helper/tree/v3.6.0?tab=readme-ov-file#create-comment) 来自动关闭不再处理的 issue，具体为标记了 "stale", "wontfix", "notabug" 的 issue

当发现 issue 长时间不活跃、非 bug、不计划修复，可以按照以下步骤快速处理：

为 issue **手动添加 "stale", "wontfix", "notabug" 标签**后，工作流会自动：

- 自动在 issue 下添加预设的评论
- 关闭此 issue

