### PR TITLE
feat: auto close issues with 'resolved pending release' label on release

### DIFF
--- a/.github/workflows/resolved-pending-release.yml
+++ b/.github/workflows/resolved-pending-release.yml
@@ -1,0 +1,27 @@
+name: Resolved Pending Release
+
+on:
+  release:
+    types: [published]
+
+permissions: {}
+
+jobs:
+  comment-on-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Check this repository out, otherwise the script won't be available,
+          # as it otherwise checks out the repository where the workflow caller is located
+          repository: antvis/github-config
+
+      - name: Comment on issues
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const script = require('./.github/workflows/scripts/closeOnRelease.js');
+            await script({core, github, context});

--- a/.github/workflows/scripts/closeOnRelease.js
+++ b/.github/workflows/scripts/closeOnRelease.js
@@ -10,6 +10,7 @@ module.exports = async ({ core, github, context }) => {
     const repo = context.repo.repo;
 
     const label = "resolved pending release";
+    const resolvedLabel = "resolved";
 
     const issuesPendingRelease = (
       await github.paginate(github.rest.issues.listForRepo, {
@@ -45,6 +46,22 @@ module.exports = async ({ core, github, context }) => {
       const message = `:tada: This issue has been resolved and is now available in the [${release.tag_name}](${release.html_url}) release! :tada:`;
 
       try {
+        // Remove the `resolved pending release` label.
+        await github.rest.issues.removeLabel({
+          owner,
+          repo,
+          issue_number: number,
+          name: label,
+        });
+
+        // Add the `resolved` label.
+        await github.rest.issues.addLabels({
+          owner,
+          repo,
+          issue_number: number,
+          labels: resolvedLabel,
+        });
+
         // Comment on the issue that we will close.
         await github.rest.issues.createComment({
           owner,

--- a/.github/workflows/scripts/closeOnRelease.js
+++ b/.github/workflows/scripts/closeOnRelease.js
@@ -1,0 +1,81 @@
+/**
+ * @param {Object} param
+ * @param {import('@actions/core')} param.core
+ * @param {ReturnType<import('@actions/github').getOctokit>} param.github
+ * @param {import('@actions/github').context} param.context
+ */
+module.exports = async ({ core, github, context }) => {
+  try {
+    const owner = context.repo.owner;
+    const repo = context.repo.repo;
+
+    const label = "resolved pending release";
+
+    const issuesPendingRelease = (
+      await github.paginate(github.rest.issues.listForRepo, {
+        owner,
+        repo,
+        state: "open",
+        per_page: 100,
+      })
+    ).filter(
+      (i) =>
+        i.pull_request === undefined &&
+        i.labels.map((l) => l.name).includes(label)
+    );
+
+    let failedIssues = 0;
+
+    for (const issue of issuesPendingRelease) {
+      const number = issue.number;
+
+      // slow down how often we send requests if there are lots of issues.
+      await new Promise((resolve) => setTimeout(resolve, 250));
+
+      const { data: releases } = await github.rest.repos.listReleases({
+        owner,
+        repo,
+      });
+      const release = releases.length > 0 ? releases[0] : undefined;
+
+      if (release === undefined) {
+        throw new Error("There is no release available");
+      }
+
+      const message = `:tada: This issue has been resolved and is now available in the [${release.tag_name}](${release.html_url}) release! :tada:`;
+
+      try {
+        // Comment on the issue that we will close.
+        await github.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: number,
+          body: message,
+        });
+
+        // Close the issue.
+        await github.rest.issues.update({
+          owner,
+          repo,
+          issue_number: number,
+          state: "closed",
+        });
+      } catch (error) {
+        console.error(
+          `Failed to comment on and/or close issue #${number}`,
+          error
+        );
+        failedIssues++;
+      }
+
+      console.log(`Closed #${number}`);
+    }
+
+    if (failedIssues > 0) {
+      core.setFailed(`Failed to comment on ${failedIssues} PRs`);
+    }
+  } catch (error) {
+    console.error(error);
+    core.setFailed(error.message);
+  }
+};

--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ When an issue is labeled, the workflow will automatically:
    - Add a pre-canned comment explaining the decision
    - Close the issue
 
+### `resolved-pending-release.yml`
+
+This workflow will resolve issues that have been resolved and are pending release.
+
+When a release is published, the workflow will automatically:
+
+- Check if there are any issues that labeled with `resolved pending release`
+- If there are, it will add a comment to the issue with a message about the release
+- Close the issue
+
 ## Issue templates
 
 | Template                | Description                                                                               |

--- a/README.md
+++ b/README.md
@@ -143,17 +143,17 @@ When an issue is labeled, the workflow will automatically:
 3. If `stale` label is added, the workflow will automatically:
 
    - Add a pre-canned comment about inactivity
-   - Close the issue
+   - Close the issue as not-planned
 
 4. If `wontfix` label is added, the workflow will automatically:
 
    - Add a pre-canned comment explaining the decision
-   - Close the issue
+   - Close the issue as not-planned
 
 5. If `notabug` label is added, the workflow will automatically:
 
    - Add a pre-canned comment explaining the decision
-   - Close the issue
+   - Close the issue as not-planned
 
 ### `resolved-pending-release.yml`
 
@@ -161,9 +161,12 @@ This workflow will resolve issues that have been resolved and are pending releas
 
 When a release is published, the workflow will automatically:
 
-- Check if there are any issues that labeled with `resolved pending release`
-- If there are, it will add a comment to the issue with a message about the release
-- Close the issue
+- Find open issues that labeled with `resolved pending release`
+- If there are,
+  - Remove the `resolved pending release` label
+  - Add the `resolved` label
+  - Add a comment to the issue with a message about the release
+  - Close the issue as completed
 
 ## Issue templates
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ We divide them based on the typical flow of an issue's lifecycle: **Discovery**,
 | Label                    | Color                                            | Hex       | Description                                                                                              |
 | ------------------------ | ------------------------------------------------ | --------- | -------------------------------------------------------------------------------------------------------- |
 | resolved                 | ![](https://dummyimage.com/100x20/008672&text=+) | `#0E8A16` | This issue has been resolved and is now available in the latest release.                                 |
-| resolved-pending-release | ![](https://dummyimage.com/100x20/008672&text=+) | `#0E8A16` | This issue has been resolved and is pending release.                                                     |
+| resolved pending release | ![](https://dummyimage.com/100x20/008672&text=+) | `#0E8A16` | This issue has been resolved and is pending release.                                                     |
 | stale                    | ![](https://dummyimage.com/100x20/eeeeee&text=+) | `#eeeeee` | This issue has not had recent activity or appears to be solved. It will be automatically closed.         |
 | wontfix                  | ![](https://dummyimage.com/100x20/eeeeee&text=+) | `#eeeeee` | This issue will not be fixed or otherwise handled. It will be automatically closed.                      |
 | notabug                  | ![](https://dummyimage.com/100x20/eeeeee&text=+) | `#eeeeee` | This issue reported is not a bug (e.g., misreported, not reproducible) and will be automatically closed. |

--- a/README.md
+++ b/README.md
@@ -61,11 +61,13 @@ We divide them based on the typical flow of an issue's lifecycle: **Discovery**,
 
 #### 4. Resolution Stage (Labels for the final stage of an issue when it is either resolved or closed)
 
-| Label   | Color                                            | Hex       | Description                                                                                              |
-| ------- | ------------------------------------------------ | --------- | -------------------------------------------------------------------------------------------------------- |
-| stale   | ![](https://dummyimage.com/100x20/eeeeee&text=+) | `#eeeeee` | This issue has not had recent activity or appears to be solved. It will be automatically closed.         |
-| wontfix | ![](https://dummyimage.com/100x20/eeeeee&text=+) | `#eeeeee` | This issue will not be fixed or otherwise handled. It will be automatically closed.                      |
-| notabug | ![](https://dummyimage.com/100x20/eeeeee&text=+) | `#eeeeee` | This issue reported is not a bug (e.g., misreported, not reproducible) and will be automatically closed. |
+| Label                    | Color                                            | Hex       | Description                                                                                              |
+| ------------------------ | ------------------------------------------------ | --------- | -------------------------------------------------------------------------------------------------------- |
+| resolved                 | ![](https://dummyimage.com/100x20/008672&text=+) | `#0E8A16` | This issue has been resolved and is now available in the latest release.                                 |
+| resolved-pending-release | ![](https://dummyimage.com/100x20/008672&text=+) | `#0E8A16` | This issue has been resolved and is pending release.                                                     |
+| stale                    | ![](https://dummyimage.com/100x20/eeeeee&text=+) | `#eeeeee` | This issue has not had recent activity or appears to be solved. It will be automatically closed.         |
+| wontfix                  | ![](https://dummyimage.com/100x20/eeeeee&text=+) | `#eeeeee` | This issue will not be fixed or otherwise handled. It will be automatically closed.                      |
+| notabug                  | ![](https://dummyimage.com/100x20/eeeeee&text=+) | `#eeeeee` | This issue reported is not a bug (e.g., misreported, not reproducible) and will be automatically closed. |
 
 ## GitHub Actions workflows
 


### PR DESCRIPTION
当发布新版本时，此工作流会自动处理已解决待发布的问题。

工作流会自动执行以下操作：

- 查找标记为 `resolved pending release` 的未关闭问题
- 如果找到相关问题，会：
  - 移除 `resolved pending release` 标签
  - 添加 `resolved` 标签
  - 在问题下添加一条关于发布信息的提示评论
  - 将问题标记为已完成并关闭
